### PR TITLE
remove [DEPRECATED] Field 'allocate_public_ip'

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,8 +39,6 @@ resource "alicloud_instance" "instances" {
   internet_charge_type = "${var.internet_charge_type}"
   internet_max_bandwidth_out = "${var.internet_max_bandwidth_out}"
 
-  allocate_public_ip = "${var.allocate_public_ip}"
-
   instance_charge_type = "${var.instance_charge_type}"
   system_disk_category = "${var.system_category}"
   system_disk_size = "${var.system_size}"

--- a/variables.tf
+++ b/variables.tf
@@ -116,11 +116,6 @@ variable "password" {
   default = ""
 }
 
-variable "allocate_public_ip" {
-  description = "Default to allocate public ip for new instances."
-  default = true
-}
-
 variable "internet_charge_type" {
   description = "The internet charge type of instance. Choices are 'PayByTraffic' and 'PayByBandwidth'."
   default = "PayByTraffic"


### PR DESCRIPTION
Running `terraform apply` hit the issue below.
```Error: Error applying plan:

1 error(s) occurred:

* alicloud_instance.instances: 1 error(s) occurred:

* alicloud_instance.instances: Error creating Aliyun ecs instance: &common.Error{ErrorResponse:common.ErrorResponse{Response:common.Response{RequestId:"9DEEC05A-7458-469C-BBAE-F37BA9BCD82C"}, HostId:"ecs-cn-hangzhou.aliyuncs.com", Code:"Zone.NotOnSale", Message:"The specified zone is not available for purchase."}, StatusCode:403}```
